### PR TITLE
Specify required version of ESP32 board definitions for Arduino IDE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ a) Arduino IDE 1.8.13
 ## Board Library
 a) esp8266 2.7.4 http://arduino.esp8266.com/stable/package_esp8266com_index.json
 
-b) for esp32 https://github.com/espressif/arduino-esp32
+b) for esp32 1.0.6 https://github.com/espressif/arduino-esp32
 
 # Libraries
 a) ArduinoThread 2.1.1


### PR DESCRIPTION
Version 1.0.6 works for me. Newer versions of the board definitions cause misleading compilation errors about missing tokens or something in baseHeader.h

I sent over a donation last night as well, next round is on me. Thanks so much for sharing this with the world!